### PR TITLE
Upgrade CoinCap API and add API key

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
@@ -5,6 +8,11 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+val localProperties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localProperties.load(FileInputStream(localPropertiesFile))
+}
 
 android {
     namespace = "com.plcoding.cryptotracker"
@@ -25,7 +33,8 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField("String", "BASE_URL", "\"https://api.coincap.io/v2/\"")
+            buildConfigField("String", "BASE_URL", "\"https://api.coincap.io/v3/\"")
+            buildConfigField("String", "API_KEY", "\"${localProperties.getProperty("API_KEY", "")}\"")
         }
         release {
             isMinifyEnabled = false
@@ -34,7 +43,8 @@ android {
                 "proguard-rules.pro"
             )
 
-            buildConfigField("String", "BASE_URL", "\"https://api.coincap.io/v2/\"")
+            buildConfigField("String", "BASE_URL", "\"https://api.coincap.io/v3/\"")
+            buildConfigField("String", "API_KEY", "\"${localProperties.getProperty("API_KEY", "")}\"")
         }
     }
     compileOptions {

--- a/app/src/main/java/com/plcoding/cryptotracker/core/data/networking/HttpClientFactory.kt
+++ b/app/src/main/java/com/plcoding/cryptotracker/core/data/networking/HttpClientFactory.kt
@@ -1,5 +1,6 @@
 package com.plcoding.cryptotracker.core.data.networking
 
+import com.plcoding.cryptotracker.BuildConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -8,6 +9,7 @@ import io.ktor.client.plugins.logging.ANDROID
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
@@ -30,6 +32,7 @@ object HttpClientFactory {
             }
             defaultRequest {
                 contentType(ContentType.Application.Json)
+                header("Authorization", "Bearer ${BuildConfig.API_KEY}")
             }
         }
     }


### PR DESCRIPTION
This pull request updates the app to support authenticated requests to the CoinCap API by introducing API key handling and updating the API version. The most important changes include reading the API key from `local.properties`, updating the API base URL, and ensuring the API key is sent in all HTTP requests.

**API Configuration Updates:**

* The `BASE_URL` for the CoinCap API was updated from `v2` to `v3` in both debug and release build types in `app/build.gradle.kts`. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L28-R37) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L37-R47)
* A new `API_KEY` build config field is added, which reads its value from the `local.properties` file if present. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R1-R15) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L28-R37) [[3]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L37-R47)

**Networking Enhancements:**

* The `HttpClientFactory` now adds an `Authorization` header with the API key to every request, enabling authenticated access to the CoinCap API. [[1]](diffhunk://#diff-1841b17aa84ccb88b67709e7f94826ccb4704c6e74182671bbdc44f6f67c294bR3) [[2]](diffhunk://#diff-1841b17aa84ccb88b67709e7f94826ccb4704c6e74182671bbdc44f6f67c294bR12) [[3]](diffhunk://#diff-1841b17aa84ccb88b67709e7f94826ccb4704c6e74182671bbdc44f6f67c294bR35)